### PR TITLE
添加多账号支持

### DIFF
--- a/bili_src/basicFunc.py
+++ b/bili_src/basicFunc.py
@@ -6,6 +6,8 @@ import sys
 import traceback
 from nonebot import get_bot
 from nonebot.log import logger
+import nonebot
+from nonebot.adapters.onebot.v11.adapter import Adapter
 from os.path import abspath, dirname
 from nonebot.adapters.onebot.v11.event import GroupMessageEvent, PrivateMessageEvent
 from .db import bili_database
@@ -58,9 +60,15 @@ async def SendMsgToUsers(msg: str, users: List[str]):
     -------
     """
     
-    bot = get_bot()
+    # bot = get_bot()
+    bots = nonebot.get_adapter(Adapter).bots
     for user in users:
-        await bot.send_msg(message=msg, user_id = user)
+        for bot in bots:
+            try:
+                await bots[bot].send_msg(message=msg, user_id = user)
+            except:
+                pass
+        # await bot.send_msg(message=msg, user_id = user)
     
 async def SendMsgToGroups(msg: str, groups: List[str]):
     '''向所有群组发送公告
@@ -70,9 +78,15 @@ async def SendMsgToGroups(msg: str, groups: List[str]):
         groups (List[str]): 群组列表
     '''
     
-    bot = get_bot()
+    # bot = get_bot()
+    bots = nonebot.get_adapter(Adapter).bots
     for group in groups:
-        await bot.send_msg(message=msg, group_id = group)
+        for bot in bots:
+            try:
+                await bots[bot].send_msg(message=msg, group_id = group)
+            except:
+                pass
+        # await bot.send_msg(message=msg, group_id = group)
 
 async def create_user(event: Union[PrivateMessageEvent, GroupMessageEvent]) -> None:
     '''接受消息后,创建用户

--- a/bili_src/biliStream.py
+++ b/bili_src/biliStream.py
@@ -3,6 +3,7 @@ import sys
 import traceback
 import nonebot
 from nonebot.log import logger
+from nonebot.adapters.onebot.v11.adapter import Adapter
 from nonebot.adapters.onebot.v11 import MessageSegment
 from .basicFunc import *
 from .exception import *
@@ -25,7 +26,8 @@ async def check_bili_live() -> None:
     logger.debug("running check_bili_live")
     liver_list = list(bili_task_manager.liver_list.values())
     
-    sched_bot = nonebot.get_bot()
+    # sched_bot = nonebot.get_bot()
+    bots = nonebot.get_adapter(Adapter).bots
     
     """results = await asyncio.gather(
         *[bili_client.get_live_status(liver_info[0], liver_info[3]) for liver_info in liver_list],
@@ -47,9 +49,19 @@ async def check_bili_live() -> None:
                 #bili_database.update_info(1, 1, liver_list[i][0])
 
                 user_list = liver_list[i]["user_follower"]
-                await asyncio.gather(*[sched_bot.send_msg(message=reported_msg, user_id=user_id) for user_id in user_list])
+                for bot in bots:
+                    try:
+                        #await asyncio.gather(*[sched_bot.send_msg(message=reported_msg, user_id=user_id) for user_id in user_list])
+                        await asyncio.gather(*[bots[bot].send_msg(message=reported_msg, user_id=user_id) for user_id in user_list])
+                    except:
+                        pass
                 group_list = liver_list[i]["group_follower"]
-                await asyncio.gather(*[sched_bot.send_msg(message=reported_msg, group_id=group_id) for group_id in group_list])
+                for bot in bots:
+                    try:
+                        #await asyncio.gather(*[sched_bot.send_msg(message=reported_msg, group_id=group_id) for group_id in group_list])
+                        await asyncio.gather(*[bots[bot].send_msg(message=reported_msg, group_id=group_id) for group_id in group_list])
+                    except:
+                        pass
 
             elif not results[i][0] and liver_list[i]["is_live"]:
                 logger.info(f'[{__PLUGIN_NAME}]检测到主播 <{liver_list[i]["liver_name"]}> 已下播')

--- a/bili_src/biliVideo.py
+++ b/bili_src/biliVideo.py
@@ -5,6 +5,7 @@ import sys
 import traceback
 import nonebot
 from nonebot.log import logger
+from nonebot.adapters.onebot.v11.adapter import Adapter
 from nonebot.adapters.onebot.v11 import MessageSegment
 from .basicFunc import *
 from .bili_client import bili_client
@@ -24,7 +25,8 @@ async def check_up_update() -> None:
     -------
     """
     logger.debug("running check_up_update")
-    schedBot = nonebot.get_bot()
+    # schedBot = nonebot.get_bot()
+    bots = nonebot.get_adapter(Adapter).bots
     #assert status == True, "数据库发生错误"
     check_up_list = bili_task_manager.get_up_check_update_list()
     #logger.debug(f'{__PLUGIN_NAME}check_up_list = {check_up_list}')
@@ -47,11 +49,21 @@ async def check_up_update() -> None:
 
                 user_list = bili_task_manager.up_list[up_uid]["user_follower"]
                 for user_id in user_list:
-                    await schedBot.send_msg(message=textMsg + MessageSegment.image(results[i][4]), user_id=user_id)
+                    for bot in bots:
+                        try:
+                            await bots[bot].send_msg(message=textMsg + MessageSegment.image(results[i][4]), user_id=user_id)
+                        except:
+                            pass
+                    # await schedBot.send_msg(message=textMsg + MessageSegment.image(results[i][4]), user_id=user_id)
                 
                 group_list = bili_task_manager.up_list[up_uid]["group_follower"]
                 for group_id in group_list:
-                    await schedBot.send_msg(message=textMsg + MessageSegment.image(results[i][4]), group_id=group_id)
+                    for bot in bots:
+                        try:
+                            await bots[bot].send_msg(message=textMsg + MessageSegment.image(results[i][4]), group_id=group_id)
+                        except:
+                            pass
+                    # await schedBot.send_msg(message=textMsg + MessageSegment.image(results[i][4]), group_id=group_id)
         elif isinstance(results[i], (BiliAPIRetCodeError, BiliStatusCodeError, BiliConnectionError)):
             exception_msg = f'[错误报告]\n检测up主 <{check_up_list[i]}> 更新情况时发生错误\n错误类型: {type(results[i])}\n错误信息: {results[i]}'
             logger.error(f"[{__PLUGIN_NAME}]" + exception_msg)

--- a/bili_src/bili_dynamic.py
+++ b/bili_src/bili_dynamic.py
@@ -5,6 +5,7 @@ import sys
 import traceback
 import nonebot
 from nonebot.log import logger
+from nonebot.adapters.onebot.v11.adapter import Adapter
 from nonebot.adapters.onebot.v11 import Message, MessageSegment
 from .basicFunc import *
 from .bili_client import bili_client
@@ -26,7 +27,8 @@ async def check_dynamic_update() -> None:
     -------
     """
     logger.debug("running check_dynamic_update")
-    schedBot = nonebot.get_bot()
+    # schedBot = nonebot.get_bot()
+    bots = nonebot.get_adapter(Adapter).bots
     check_dynamic_list = bili_task_manager.get_dynamic_check_update_list()
     #logger.debug(f'{__PLUGIN_NAME}check_dynamic_list = {check_dynamic_list}')
     
@@ -111,11 +113,21 @@ async def check_dynamic_update() -> None:
                 if len(info_msg) != 1:
                     user_list = bili_task_manager.dynamic_list[uid]["user_follower"]
                     for user_id in user_list:
-                        await schedBot.send_msg(message=info_msg, user_id=user_id)
+                        for bot in bots:
+                            try:
+                                #await schedBot.send_msg(message=info_msg, user_id=user_id)
+                                await bots[bot].send_msg(message=info_msg, user_id=user_id)
+                            except:
+                                pass
                     
                     group_list = bili_task_manager.dynamic_list[uid]["group_follower"]
                     for group_id in group_list:
-                        await schedBot.send_msg(message=info_msg, group_id=group_id)
+                        for bot in bots:
+                            try:
+                                #await schedBot.send_msg(message=info_msg, group_id=group_id)
+                                await bots[bot].send_msg(message=info_msg, group_id=group_id)
+                            except:
+                                pass
 
         elif isinstance(results[i], (BiliAPIRetCodeError, BiliStatusCodeError, BiliConnectionError)):
             exception_msg = f'[错误报告]\n检测动态主 <{check_dynamic_list[i]}> 更新情况时发生错误\n错误类型: {type(results[i])}\n错误信息: {results[i]}'


### PR DESCRIPTION
当nonebot连接到多个bot端时，默认的get_bot只会获取到第一个连接的bot，
有时其他bot绑定的推送会使用get_bot获得的第一个bot发送，进而发送失败，无法正常推送。
于是获取bot列表，对每个bot进行发送尝试。